### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "dependencies": {
     "bluebird": "^2.5.2",
     "lodash": "^2.4.1",
-    "node-uuid": "^1.4.2"
+    "uuid": "^3.0.0"
   }
 }

--- a/test/event_stream.js
+++ b/test/event_stream.js
@@ -1,6 +1,6 @@
 var should = require('should');
 var Promise = require('bluebird');
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 
 var EventStore = require('..');
 var EventStream = require('../lib/event_stream');

--- a/test/persistence/inmemory.js
+++ b/test/persistence/inmemory.js
@@ -1,5 +1,5 @@
 var should = require('should');
-var uuid = require("node-uuid").v4;
+var uuid = require("uuid").v4;
 var Promise = require("bluebird");
 
 var Store = require('../../lib/persistence/inmemory/inmemory_persistence');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.