### PR TITLE
build(vitest): replace mocha, should, and istanbul with vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.4",
-        "istanbul": "^0.3.2",
-        "mocha": "^2.0.1",
-        "should": "^4.1.0"
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -183,694 +181,1350 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-      "dev": true
-    },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
+      "os": [
+        "aix"
+      ],
       "engines": {
-        "node": ">=0.4.2"
+        "node": ">=18"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
       "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
-    "node_modules/async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/bluebird": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "node_modules/deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "node_modules/diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
-      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=0.3.1"
+        "node": ">=8"
       }
     },
-    "node_modules/escodegen": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
-      "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esprima": "^1.2.2",
-        "estraverse": "^1.9.1",
-        "esutils": "^2.0.2",
-        "optionator": "^0.5.0"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
+        "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=0.12.0"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "source-map": "~0.2.0"
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
-    "node_modules/escodegen/node_modules/esprima": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-      "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-      "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "deep-is": "~0.1.2",
-        "fast-levenshtein": "~1.0.0",
-        "levn": "~0.2.5",
-        "prelude-ls": "~1.1.1",
-        "type-check": "~0.3.1",
-        "wordwrap": "~0.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
+        "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">=0.8.0"
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
-      "dev": true
-    },
-    "node_modules/fileset": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-      "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
-      "dev": true,
-      "dependencies": {
-        "glob": "5.x",
-        "minimatch": "2.x"
-      }
-    },
-    "node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-      "dev": true
-    },
-    "node_modules/handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
-      "dev": true,
-      "dependencies": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/handlebars/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "node_modules/istanbul": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
-      "integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
-      "deprecated": "This module is no longer maintained, try this instead:\n  npm i nyc\nVisit https://istanbul.js.org/integrations for other alternatives.",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1.0.x",
-        "async": "1.x",
-        "escodegen": "1.7.x",
-        "esprima": "2.5.x",
-        "fileset": "0.2.x",
-        "handlebars": "^4.0.1",
-        "js-yaml": "3.x",
-        "mkdirp": "0.5.x",
-        "nopt": "3.x",
-        "once": "1.x",
-        "resolve": "1.1.x",
-        "supports-color": "^3.1.0",
-        "which": "^1.1.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "istanbul": "lib/cli.js"
-      }
-    },
-    "node_modules/istanbul/node_modules/esprima": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
-      "integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/istanbul/node_modules/resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
-    },
-    "node_modules/istanbul/node_modules/supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/istanbul/node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
-    "node_modules/jade": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
-      "dev": true,
-      "dependencies": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
-      },
-      "bin": {
-        "jade": "bin/jade"
-      }
-    },
-    "node_modules/jade/node_modules/commander": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-      "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.x"
-      }
-    },
-    "node_modules/jade/node_modules/mkdirp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-      "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.5.tgz",
-      "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.2",
-        "esprima": "^2.6.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/js-yaml/node_modules/esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.0",
-        "type-check": "~0.3.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
-    },
-    "node_modules/minimatch": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "brace-expansion": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "minimist": "0.0.8"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
       },
       "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "node_modules/mocha": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
-      "dev": true,
-      "dependencies": {
-        "commander": "2.3.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.2",
-        "glob": "3.2.11",
-        "growl": "1.9.2",
-        "jade": "0.26.3",
-        "mkdirp": "0.5.1",
-        "supports-color": "1.2.0",
-        "to-iso-string": "0.0.2"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">= 0.8.x"
-      }
-    },
-    "node_modules/mocha/node_modules/commander": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-      "dev": true,
-      "dependencies": {
-        "ms": "0.7.1"
-      }
-    },
-    "node_modules/mocha/node_modules/escape-string-regexp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-      "dev": true,
-      "dependencies": {
-        "inherits": "2",
-        "minimatch": "0.3"
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
       },
-      "engines": {
-        "node": "*"
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
       }
     },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
+      "license": "ISC"
     },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
-      "bin": {
-        "supports-color": "cli.js"
-      },
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
-    },
-    "node_modules/nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-      "dev": true
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/should": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/should/-/should-4.6.5.tgz",
-      "integrity": "sha1-DRI0bbvRsCj59Lt6nVRzZPw2qH8=",
-      "dev": true,
-      "dependencies": {
-        "should-equal": "0.3.1",
-        "should-format": "0.0.7",
-        "should-type": "0.0.4"
-      }
-    },
-    "node_modules/should-equal": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
-      "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
-      "dev": true,
-      "dependencies": {
-        "should-type": "0.0.4"
-      }
-    },
-    "node_modules/should-format": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.0.7.tgz",
-      "integrity": "sha1-Hi74a9kdqcLgQSM1tWq6vZov3hI=",
-      "dev": true,
-      "dependencies": {
-        "should-type": "0.0.4"
-      }
-    },
-    "node_modules/should-type": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.4.tgz",
-      "integrity": "sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=",
-      "dev": true
-    },
-    "node_modules/sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "node_modules/to-iso-string": {
+    "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-      "deprecated": "to-iso-string has been deprecated, use @segment/to-iso-string instead.",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
-    "node_modules/type-check": {
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "prelude-ls": "~1.1.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
-      "optional": true,
-      "dependencies": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=0.8.0"
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
-    "node_modules/uglify-js/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
-      "optional": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/uuid": {
@@ -881,32 +1535,193 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+    "node_modules/vite": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
+      "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "isexe": "^2.0.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "dev": true,
+        "vite": "bin/vite.js"
+      },
       "engines": {
-        "node": ">=0.4.0"
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha test --recursive",
-    "test.watch": "mocha test --watch --recursive",
-    "test.ci": "istanbul cover node_modules/mocha/bin/_mocha -- --recursive test -u exports -R tap >> tape.tap && istanbul report clover",
-    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --recursive test -u exports -R spec",
-    "coverage-start": "istanbul cover node_modules/mocha/bin/_mocha test --recursive -- -u exports -R spec && start coverage/lcov-report/index.html",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
     "check": "biome check lib test",
     "format": "biome format lib test",
     "format:fix": "biome format --write lib test",
@@ -31,9 +28,7 @@
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
-    "istanbul": "^0.3.2",
-    "mocha": "^2.0.1",
-    "should": "^4.1.0"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "bluebird": "^2.5.2",

--- a/test/event_partition.js
+++ b/test/event_partition.js
@@ -1,232 +1,151 @@
-var should = require("should");
-var Promise = require("bluebird");
-var uuid = require("uuid").v4;
+import { v4 as uuid } from "uuid";
+import { describe, expect, it } from "vitest";
+import EventStore, { Commit } from "..";
 
-var EventStore = require("..");
-var Commit = EventStore.Commit;
+describe("Partition", () => {
+  describe("#append", () => {
+    it("should return commit if added", async (done) => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      const c = await partition.append(new Commit("1", "location", "1", 0, []));
+      expect(c[0].events).toHaveLength(0);
+    });
 
-describe("Partition", function () {
-  describe("#append", function (done) {
-    it("should return commit if added", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .then(function (partition) {
-          partition.append(new Commit("1", "location", "1", 0, [])).then(function (c) {
-            c[0].events.length.should.equal(0);
-            done();
-          });
-        })
-        .catch(function (err) {
-          done(err);
-        });
-    });
-    it("should return after all commits are persisted", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .then(function (partition) {
-          return partition.append([new Commit("1", "location", "1", 0, []), new Commit("2", "location", "1", 1, [])]).then(function (c) {
-            c.length.should.equal(2);
-            done();
-          });
-        })
-        .catch(function (err) {
-          done(err);
-        });
+    it("should return after all commits are persisted", async () => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      const c = await partition.append([new Commit("1", "location", "1", 0, []), new Commit("2", "location", "1", 1, [])]);
+      expect(c).toHaveLength(2);
     });
   });
-  describe("#_truncateStreamFrom", function () {
-    it("should remove all commits ", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .then(function (partition) {
-          return partition.append([new Commit("1", "location", "1", 0, []), new Commit("2", "location", "1", 1, [])]).then(function (c) {
-            return partition._truncateStreamFrom("1", 0).then(function () {
-              return partition.openStream("1").then(function (stream) {
-                stream.getVersion().should.equal(-1);
-                done();
-              });
-            });
-          });
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+  describe("#_truncateStreamFrom", () => {
+    it("should remove all commits ", async () => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      await partition.append([new Commit("1", "location", "1", 0, []), new Commit("2", "location", "1", 1, [])]);
+      await partition._truncateStreamFrom("1", 0);
+      const stream = await partition.openStream("1");
+      expect(stream.getVersion()).toBe(-1);
     });
-    it("should remove all commits after commitSequence", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .then(function (partition) {
-          return partition.append([new Commit("1", "location", "1", 0, [{}]), new Commit("2", "location", "1", 1, [{}])]).then(function (c) {
-            return partition._truncateStreamFrom("1", 1).then(function () {
-              return partition.openStream("1").then(function (stream) {
-                stream.getVersion().should.equal(1);
-                done();
-              });
-            });
-          });
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+    it("should remove all commits after commitSequence", async () => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      await partition.append([new Commit("1", "location", "1", 0, [{}]), new Commit("2", "location", "1", 1, [{}])]);
+      await partition._truncateStreamFrom("1", 1);
+      const stream = await partition.openStream("1");
+      expect(stream.getVersion()).toBe(1);
     });
   });
-  describe("#_applyCommitHeader", function () {
-    it("should add to commit ", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .then(function (partition) {
-          var commit = new Commit("1", "location", "1", 0, []);
-          return partition.append([commit, new Commit("2", "location", "1", 1, [])]).then(function (c) {
-            return partition._applyCommitHeader(commit.id, { authorative: true }).then(function (commit) {
-              commit.authorative.should.be.ok;
-              done();
-            });
-          });
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+  describe("#_applyCommitHeader", () => {
+    it("should add to commit ", async () => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      let commit = new Commit("1", "location", "1", 0, []);
+      await partition.append([commit, new Commit("2", "location", "1", 1, [])]);
+      commit = await partition._applyCommitHeader(commit.id, {
+        authorative: true,
+      });
+      expect(commit.authorative).toBeTruthy();
     });
-    it("should throw if commit id is unknown", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .then(function (partition) {
-          var commit = new Commit("1", "location", "1", 0, []);
-          return partition.append([commit, new Commit("2", "location", "1", 1, [])]).then(function (c) {
-            return partition._applyCommitHeader("ID MISSING", { authorative: true }).then(function (commit) {
-              done(new Error("Unreachable code"));
-            });
-          });
-        })
-        .catch(function (err) {
-          done();
-        });
+
+    it("should throw if commit id is unknown", async () => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      const commit = new Commit("1", "location", "1", 0, []);
+      await partition.append([commit, new Commit("2", "location", "1", 1, [])]);
+
+      expect(() => partition._applyCommitHeader("ID MISSING", { authorative: true })).toThrow("Trying to apply header to missing commit: ID MISSING");
     });
   });
-  describe("#queryStreamWithSnapshot", function () {
-    it("queryStreamWithSnapshot should return snapshot and missing commits", function (done) {
-      var es = new EventStore();
-      var streamId = "1";
-      var stream;
-      es.openPartition("location")
-        .call("openStream", streamId)
-        .then(function (stream1) {
-          stream = stream1;
-          stream.append({ event: "123" });
-          stream.append({ event: "999" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.append({ event: "666" });
-          stream.append({ event: "777" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          es.openPartition("location").then(function (part) {
-            part.storeSnapshot(streamId, { test: "snapshot" }, 2);
-            part.queryStreamWithSnapshot(streamId).then(function (res) {
-              res.snapshot.version.should.eql(2);
-              res.commits.length.should.eql(1);
-              res.commits[0].events.length.should.eql(2);
-              res.commits[0].events[0].version.should.eql(2);
-              done();
-            });
-          });
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+  describe("#queryStreamWithSnapshot", () => {
+    it("queryStreamWithSnapshot should return snapshot and missing commits", async () => {
+      const es = new EventStore();
+      const streamId = "1";
+      const stream = await es.openPartition("location").call("openStream", streamId);
+
+      stream.append({ event: "123" });
+      stream.append({ event: "999" });
+      await stream.commit(uuid());
+
+      stream.append({ event: "666" });
+      stream.append({ event: "777" });
+      await stream.commit(uuid());
+
+      const part = await es.openPartition("location");
+      part.storeSnapshot(streamId, { test: "snapshot" }, 2);
+      const res = await part.queryStreamWithSnapshot(streamId);
+
+      expect(res.snapshot.version).toBe(2);
+      expect(res.commits).toHaveLength(1);
+      expect(res.commits[0].events).toHaveLength(2);
+      expect(res.commits[0].events[0].version).toBe(2);
     });
-    it("queryStreamWithSnapshot should return snapshot and no commit if up to date", function (done) {
-      var es = new EventStore();
-      var streamId = "1";
-      es.openPartition("location")
-        .call("openStream", streamId)
-        .then(function (stream) {
-          stream.append({ event: "123" });
-          stream.append({ event: "999" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          es.openPartition("location").then(function (part) {
-            part.storeSnapshot(streamId, { test: "snapshot" }, 2);
-            part.queryStreamWithSnapshot(streamId, function (err, res) {
-              res.snapshot.version.should.eql(2);
-              res.commits.length.should.eql(0);
-              done();
-            });
-          });
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+    it("queryStreamWithSnapshot should return snapshot and no commit if up to date", async () => {
+      const es = new EventStore();
+      const streamId = "1";
+      const stream = await es.openPartition("location").call("openStream", streamId);
+
+      stream.append({ event: "123" });
+      stream.append({ event: "999" });
+      await stream.commit(uuid());
+
+      const part = await es.openPartition("location");
+      part.storeSnapshot(streamId, { test: "snapshot" }, 2);
+
+      const res = await part.queryStreamWithSnapshot(streamId);
+      expect(res.snapshot.version).toBe(2);
+      expect(res.commits).toHaveLength(0);
     });
   });
-  describe("#delete", function () {
-    it("should delete stream and all commits", function (done) {
-      var didIGetaDeleteEvent = false;
-      var es = new EventStore(null, (commit) => {
+
+  describe("#delete", () => {
+    it("should delete stream and all commits", async () => {
+      let didIGetaDeleteEvent = false;
+
+      const es = new EventStore(null, (commit) => {
         if (commit.events[0].type === "$stream.deleted.event") {
           didIGetaDeleteEvent = true;
         }
       });
-      es.openPartition("location")
-        .then(function (partition) {
-          return partition
-            .append([new Commit("1", "location", "1", 0, [{ type: "dummy.event" }]), new Commit("2", "location", "1", 1, [{ type: "dummy2.event" }])])
-            .then(function (c) {
-              return partition.delete("1", { some: "header-value", payload: { test: true }, type: "fail" }).then(function () {
-                return partition
-                  .openStream("1")
-                  .then(function (stream) {
-                    console.log(JSON.stringify(stream, null, 2));
-                    done(new Error("able to open deleted stream"));
-                  })
-                  .catch(function (error) {
-                    error.message.should.equal("Stream is deleted");
-                    didIGetaDeleteEvent.should.be.true;
-                    done();
-                  });
-              });
-            });
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+      const partition = await es.openPartition("location");
+      await partition.append([new Commit("1", "location", "1", 0, [{ type: "dummy.event" }]), new Commit("2", "location", "1", 1, [{ type: "dummy2.event" }])]);
+      await partition.delete("1", {
+        some: "header-value",
+        payload: { test: true },
+        type: "fail",
+      });
+
+      await expect(partition.openStream("1")).rejects.toThrow("Stream is deleted");
+      expect(didIGetaDeleteEvent).toBeTruthy();
     });
 
-    it("should delete and placeholder commit should have an id", function (done) {
-      var didIGetaDeleteEvent = false;
-      var es = new EventStore(null, (commit) => {
-        console.log(commit.id);
+    it("should delete and placeholder commit should have an id", async () => {
+      let didIGetaDeleteEvent = false;
+
+      const es = new EventStore(null, (commit) => {
         if (commit.events[0].type === "$stream.deleted.event" && commit.id) {
           didIGetaDeleteEvent = true;
         }
-        should(commit.id).not.be.null;
+
+        expect(commit.id).not.toBeNull();
       });
-      es.openPartition("location")
-        .then(function (partition) {
-          return partition
-            .append([new Commit("1", "location", "1", 0, [{ type: "dummy.event" }]), new Commit("2", "location", "1", 1, [{ type: "dummy2.event" }])])
-            .then(function (c) {
-              return partition.delete("1", { some: "header-value", payload: { test: true }, type: "fail" }).then(function () {
-                return partition
-                  .openStream("1")
-                  .then(function (stream) {
-                    console.log(JSON.stringify(stream, null, 2));
-                    done(new Error("able to open deleted stream"));
-                  })
-                  .catch(function (error) {
-                    error.message.should.equal("Stream is deleted");
-                    didIGetaDeleteEvent.should.be.true;
-                    done();
-                  });
-              });
-            });
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+      const partition = await es.openPartition("location");
+      await partition.append([new Commit("1", "location", "1", 0, [{ type: "dummy.event" }]), new Commit("2", "location", "1", 1, [{ type: "dummy2.event" }])]);
+      await partition.delete("1", {
+        some: "header-value",
+        payload: { test: true },
+        type: "fail",
+      });
+
+      await expect(partition.openStream("1")).rejects.toThrow("Stream is deleted");
+      expect(didIGetaDeleteEvent).toBeTruthy();
     });
   });
 });

--- a/test/event_store.js
+++ b/test/event_store.js
@@ -1,38 +1,25 @@
-var should = require("should");
-var Promise = require("bluebird");
+import Promise from "bluebird";
+import { describe, expect, it } from "vitest";
+import EventStore from "..";
 
-var EventStore = require("..");
+describe("event_store", () => {
+  describe("#openPartition", () => {
+    it("should return non null partition when using new id", async () => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      expect(partition).not.toBeNull();
+    });
 
-describe("event_store", function () {
-  describe("#openPartition", function (done) {
-    it("should return non null partition when using new id", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .then(function (partition) {
-          partition.should.not.be.null;
-          done();
-        })
-        .catch(function (err) {
-          done(err);
-        });
+    it("should return same instance when called multiple times", async () => {
+      const es = new EventStore();
+      const [p1, p2] = await Promise.all([es.openPartition("location"), es.openPartition("location")]);
+      expect(p1).toBe(p2);
     });
-    it("should return same instance when called multiple times", function (done) {
-      var es = new EventStore();
-      Promise.join(es.openPartition("location"), es.openPartition("location"), function (p1, p2) {
-        p1.should.equal(p2);
-        done();
-      }).catch(function (err) {
-        done(err);
-      });
-    });
-    it("should return different instances for different partitionIds", function (done) {
-      var es = new EventStore();
-      Promise.join(es.openPartition("location"), es.openPartition("location2"), function (p1, p2) {
-        p1.should.not.equal(p2);
-        done();
-      }).catch(function (err) {
-        done(err);
-      });
+
+    it("should return different instances for different partitionIds", async () => {
+      const es = new EventStore();
+      const [p1, p2] = await Promise.all([es.openPartition("location"), es.openPartition("location2")]);
+      expect(p1).not.toBe(p2);
     });
   });
 });

--- a/test/event_stream.js
+++ b/test/event_stream.js
@@ -1,240 +1,160 @@
-var should = require("should");
-var Promise = require("bluebird");
-var uuid = require("uuid").v4;
+import Promise from "bluebird";
+import { v4 as uuid } from "uuid";
+import { describe, expect, it } from "vitest";
+import EventStore from "..";
+import EventStream from "../lib/event_stream";
 
-var EventStore = require("..");
-var EventStream = require("../lib/event_stream");
-
-describe("event_stream", function () {
-  describe("#openStream", function (done) {
-    it("should return 0 commits for new stream", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .call("openStream", "1")
-        .then(function (stream) {
-          stream.getCommittedEvents().length.should.equal(0);
-          done();
-        })
-        .catch(function (err) {
-          done(err);
-        });
+describe("event_stream", () => {
+  describe("#openStream", () => {
+    it("should return 0 commits for new stream", async () => {
+      const es = new EventStore();
+      const stream = await es.openPartition("location").call("openStream", "1");
+      expect(stream.getCommittedEvents()).toHaveLength(0);
     });
   });
-  describe("#commit", function (done) {
-    it("should do nothing if nothing has been appended", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .call("openStream", "1")
-        .then(function (stream) {
-          stream.commit(uuid());
-          stream.getCommittedEvents().length.should.equal(0);
-          done();
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+  describe("#commit", () => {
+    it("should do nothing if nothing has been appended", async () => {
+      const es = new EventStore();
+      const stream = await es.openPartition("location").call("openStream", "1");
+      stream.commit(uuid());
+      expect(stream.getCommittedEvents()).toHaveLength(0);
     });
 
-    it("should call commit on partition", function (done) {
-      var mockPartition = {
-        called: false,
-        append: function (commit, callback) {
-          this.called = true;
+    it("should call commit on partition", () => {
+      let called = false;
+      const mockPartition = {
+        append: (commit, callback) => {
+          called = true;
           return Promise.resolve().nodeify(callback);
         },
-        _queryStream: function (streamId, callback) {
+        _queryStream: (streamId, callback) => {
           return Promise.resolve([]).nodeify(callback);
         },
       };
-      var stream = new EventStream(mockPartition, "11");
+
+      const stream = new EventStream(mockPartition, "11");
       stream.append({ event: "123" });
       stream.commit(uuid());
-      mockPartition.called.should.be.true;
-      done();
-    });
-    it("should keep track of uncommitted events", function (done) {
-      var es = new EventStore();
-      es.openPartition("location")
-        .call("openStream", "1")
-        .then(function (stream) {
-          stream.append({ event: "123" });
-          stream.getUncommittedEvents().length.should.equal(1);
-          done();
-        })
-        .catch(function (err) {
-          done(err);
-        });
-    });
-    it("should move uncommitted events to committed on commit", function (done) {
-      var es = new EventStore();
-      var stream;
-      es.openPartition("location")
-        .call("openStream", "1")
-        .then(function (stream1) {
-          stream = stream1;
-          stream.append({ event: "123" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.getUncommittedEvents().length.should.equal(0);
-          stream.getCommittedEvents().length.should.equal(1);
-          done();
-        })
-        .catch(function (err) {
-          done(err);
-        });
-    });
-    it("two events becomes one commit", function (done) {
-      var es = new EventStore();
-      var stream;
-      es.openPartition("location")
-        .call("openStream", "1")
-        .then(function (stream1) {
-          stream = stream1;
-          stream.append({ event: "123" });
-          stream.append({ event: "999" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.getCommittedEvents().length.should.equal(2);
-          stream._commitSequence.should.equal(0);
-          done();
-        })
-        .catch(function (err) {
-          done(err);
-        });
-    });
-    it("two commits gets increasing commit sequence", function (done) {
-      var es = new EventStore();
-      var stream;
-      es.openPartition("location")
-        .call("openStream", "1")
-        .then(function (stream1) {
-          stream = stream1;
-          stream.append({ event: "123" });
-          stream.append({ event: "999" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.append({ event: "666" });
-          stream.append({ event: "777" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.getCommittedEvents().length.should.equal(4);
-          stream._commitSequence.should.equal(1);
-          done();
-        })
-        .catch(function (err) {
-          done(err);
-        });
-    });
-    it("event stream writeOnly", function (done) {
-      var es = new EventStore();
-      var stream;
-      es.openPartition("location").then(function (partition) {
-        partition
-          .openStream("1", true)
-          .then(function (stream1) {
-            stream = stream1;
-            stream.append({ event: "123" });
-            return stream.commit(uuid());
-          })
-          .then(function () {
-            stream._commitSequence.should.equal(0);
-            stream.append({ event: "666" });
-            stream.append({ event: "777" });
-            return stream.commit(uuid());
-          })
-          .then(function () {
-            stream._commitSequence.should.equal(1);
-            done();
-          })
-          .catch(function (err) {
-            done(err);
-          });
-      });
-    });
-    it("committed events should have increasing version", function (done) {
-      var es = new EventStore();
-      var stream;
-      es.openPartition("location")
-        .call("openStream", "1")
-        .then(function (stream1) {
-          stream = stream1;
-          stream.append({ event: "123" });
-          stream.append({ event: "999" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.append({ event: "666" });
-          stream.append({ event: "777" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.getCommittedEvents()[3].version.should.equal(3);
-          stream._version.should.equal(4);
-          done();
-        })
-        .catch(function (err) {
-          done(err);
-        });
-    });
-    it("committed events should have increasing version (writeOnly)", function (done) {
-      var es = new EventStore();
-      var stream;
-      es.openPartition("location").then(function (partition) {
-        partition
-          .openStream("1", true)
-          .then(function (stream1) {
-            stream = stream1;
-            stream.append({ event: "123" });
-            stream.append({ event: "999" });
-            return stream.commit(uuid());
-          })
-          .then(function () {
-            stream.append({ event: "666" });
-            stream.append({ event: "777" });
-            return stream.commit(uuid());
-          })
-          .then(function () {
-            stream._version.should.equal(4);
-            done();
-          })
-          .catch(function (err) {
-            done(err);
-          });
-      });
-    });
-    it("published events should have increasing version", function (done) {
-      var commitCount = 0;
 
-      var es = new EventStore(null, function (commit) {
-        commit.events[0].should.have.property("version");
-        if (++commitCount == 2) {
-          done();
-        }
+      expect(called).toBe(true);
+    });
+
+    it("should keep track of uncommitted events", async () => {
+      const es = new EventStore();
+      const stream = await es.openPartition("location").call("openStream", "1");
+
+      stream.append({ event: "123" });
+      expect(stream.getUncommittedEvents()).toHaveLength(1);
+    });
+
+    it("should move uncommitted events to committed on commit", async () => {
+      const es = new EventStore();
+      const stream = await es.openPartition("location").call("openStream", "1");
+
+      stream.append({ event: "123" });
+      await stream.commit(uuid());
+
+      expect(stream.getUncommittedEvents()).toHaveLength(0);
+      expect(stream.getCommittedEvents()).toHaveLength(1);
+    });
+
+    it("two events becomes one commit", async () => {
+      const es = new EventStore();
+      const stream = await es.openPartition("location").call("openStream", "1");
+
+      stream.append({ event: "123" });
+      stream.append({ event: "999" });
+      await stream.commit(uuid());
+
+      expect(stream.getCommittedEvents()).toHaveLength(2);
+      expect(stream._commitSequence).toBe(0);
+    });
+
+    it("two commits gets increasing commit sequence", async () => {
+      const es = new EventStore();
+      const stream = await es.openPartition("location").call("openStream", "1");
+
+      stream.append({ event: "123" });
+      stream.append({ event: "999" });
+      await stream.commit(uuid());
+
+      stream.append({ event: "666" });
+      stream.append({ event: "777" });
+      await stream.commit(uuid());
+
+      expect(stream.getCommittedEvents()).toHaveLength(4);
+      expect(stream._commitSequence).toBe(1);
+    });
+
+    it("event stream writeOnly", async () => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      const stream = await partition.openStream("1", true);
+
+      stream.append({ event: "123" });
+      await stream.commit(uuid());
+
+      expect(stream._commitSequence).toBe(0);
+      stream.append({ event: "666" });
+      stream.append({ event: "777" });
+      await stream.commit(uuid());
+
+      expect(stream._commitSequence).toBe(1);
+    });
+
+    it("committed events should have increasing version", async () => {
+      const es = new EventStore();
+      const stream = await es.openPartition("location").call("openStream", "1");
+
+      stream.append({ event: "123" });
+      stream.append({ event: "999" });
+      await stream.commit(uuid());
+
+      stream.append({ event: "666" });
+      stream.append({ event: "777" });
+      await stream.commit(uuid());
+
+      expect(stream.getCommittedEvents()[3].version).toBe(3);
+      expect(stream._version).toBe(4);
+    });
+
+    it("committed events should have increasing version (writeOnly)", async () => {
+      const es = new EventStore();
+      const partition = await es.openPartition("location");
+      const stream = await partition.openStream("1", true);
+
+      stream.append({ event: "123" });
+      stream.append({ event: "999" });
+      await stream.commit(uuid());
+
+      stream.append({ event: "666" });
+      stream.append({ event: "777" });
+      await stream.commit(uuid());
+
+      expect(stream._version).toBe(4);
+    });
+
+    it("published events should have increasing version", async () => {
+      let commitCount = 0;
+
+      const es = new EventStore(null, (commit) => {
+        expect(commit.events[0]).toHaveProperty("version");
+        commitCount++;
       });
-      var stream;
-      es.openPartition("location")
-        .call("openStream", "1")
-        .then(function (stream1) {
-          stream = stream1;
-          stream.append({ event: "123" });
-          stream.append({ event: "999" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.append({ event: "666" });
-          stream.append({ event: "777" });
-          return stream.commit(uuid());
-        })
-        .then(function () {
-          stream.getCommittedEvents()[1].version.should.equal(1);
-        })
-        .catch(function (err) {
-          done(err);
-        });
+
+      const stream = await es.openPartition("location").call("openStream", "1");
+
+      stream.append({ event: "123" });
+      stream.append({ event: "999" });
+      await stream.commit(uuid());
+
+      stream.append({ event: "666" });
+      stream.append({ event: "777" });
+      await stream.commit(uuid());
+
+      expect(stream.getCommittedEvents()[1].version).toBe(1);
+      expect(commitCount).toBe(2);
     });
   });
 });

--- a/test/persistence/inmemory.js
+++ b/test/persistence/inmemory.js
@@ -1,173 +1,139 @@
-var should = require("should");
-var uuid = require("uuid").v4;
-var Promise = require("bluebird");
+import Promise from "bluebird";
+import { v4 as uuid } from "uuid";
+import { describe, expect, it } from "vitest";
+import Event from "../../lib/event";
+import Commit from "../../lib/persistence/commit";
+import Store from "../../lib/persistence/inmemory/inmemory_persistence";
 
-var Store = require("../../lib/persistence/inmemory/inmemory_persistence");
-var Commit = require("../../lib/persistence/commit");
-var Event = require("../../lib/event");
-var PersistenceConcurrencyError = require("../../lib/persistence/concurrency_error");
-var PersistenceDuplicateCommitError = require("../../lib/persistence/duplicate_commit_error");
+describe("inmemory_persistence", () => {
+  describe("#commit", () => {
+    it("should accept a commit and store it", async () => {
+      const store = new Store();
+      const partition = await store.openPartition("1");
+      const events = [new Event(uuid(), "type1", { test: 11 })];
+      const commit = new Commit(uuid(), "master", "1", 0, events);
 
-describe("inmemory_persistence", function () {
-  describe("#commit", function () {
-    it("should accept a commit and store it", function (done) {
-      var store = new Store();
-      store.openPartition("1").then(function (partition) {
-        var events = [new Event(uuid(), "type1", { test: 11 })];
-        var commit = new Commit(uuid(), "master", "1", 0, events);
-        partition
-          .append(commit)
-          .then(function () {
-            return partition.queryAll();
-          })
-          .then(function (x) {
-            x.length.should.equal(1);
-            done();
-          })
-          .catch(function (err) {
-            done(err);
-          });
-      });
+      await partition.append(commit);
+      const x = await partition.queryAll();
+      expect(x).toHaveLength(1);
     });
 
-    it("commit in one stream is not visible in other", function (done) {
-      var store = new Store();
-      store.openPartition("1").then(function (partition) {
-        var events = [new Event(uuid(), "type1", { test: 11 })];
-        var commit = new Commit(uuid(), "master", "1", 0, events);
-        partition.append(commit);
+    it("commit in one stream is not visible in other", async () => {
+      const store = new Store();
+      const partition = await store.openPartition("1");
 
-        var events = [new Event(uuid(), "type2", { test: 22 })];
-        var commit = new Commit(uuid(), "master", "2", 0, events);
-        partition.append(commit);
+      let events = [new Event(uuid(), "type1", { test: 11 })];
+      let commit = new Commit(uuid(), "master", "1", 0, events);
+      partition.append(commit);
 
-        Promise.join(partition.queryStream("1"), partition.queryStream("2"), function (r1, r2) {
-          r1.length.should.equal(1);
-          r2.length.should.equal(1);
-          done();
-        }).catch(function (err) {
-          done(err);
-        });
-      });
+      events = [new Event(uuid(), "type2", { test: 22 })];
+      commit = new Commit(uuid(), "master", "2", 0, events);
+      partition.append(commit);
+
+      const [r1, r2] = await Promise.all([partition.queryStream("1"), partition.queryStream("2")]);
+
+      expect(r1).toHaveLength(1);
+      expect(r2).toHaveLength(1);
     });
 
-    it("two commits in one stream are visible", function () {
-      var store = new Store();
-      store.openPartition("1").then(function (partition) {
-        var events = [new Event(uuid(), "type1", { test: 11 })];
-        var commit = new Commit(uuid(), "master", "1", 0, events);
-        partition.append(commit);
-        var events = [new Event(uuid(), "type2", { test: 22 })];
-        var commit = new Commit(uuid(), "master", "1", 1, events);
-        partition.append(commit);
-        partition.queryAll().then(function (res) {
-          res.length.should.equal(2);
-        });
-      });
+    it("two commits in one stream are visible", async () => {
+      const store = new Store();
+      const partition = await store.openPartition("1");
+
+      let events = [new Event(uuid(), "type1", { test: 11 })];
+      let commit = new Commit(uuid(), "master", "1", 0, events);
+      partition.append(commit);
+
+      events = [new Event(uuid(), "type2", { test: 22 })];
+      commit = new Commit(uuid(), "master", "1", 1, events);
+      partition.append(commit);
+
+      const res = await partition.queryAll();
+      expect(res).toHaveLength(2);
     });
 
-    it("should skip events", function () {
-      var store = new Store();
-      store.openPartition("1").then(function (partition) {
-        var events = [new Event(uuid(), "type1", { test: 11 }), new Event(uuid(), "type1", { test: 12 })];
-        var commit = new Commit(uuid(), "master", "1", 0, events);
-        partition.append(commit);
-        var events = [new Event(uuid(), "type2", { test: 22 })];
-        var commit = new Commit(uuid(), "master", "1", 1, events);
-        partition.append(commit);
-        partition.queryStream("1", 2).then(function (res) {
-          res.length.should.equal(1);
-        });
-      });
+    it("should skip events", async () => {
+      const store = new Store();
+      const partition = await store.openPartition("1");
+
+      let events = [new Event(uuid(), "type1", { test: 11 }), new Event(uuid(), "type1", { test: 12 })];
+      let commit = new Commit(uuid(), "master", "1", 0, events);
+      partition.append(commit);
+
+      events = [new Event(uuid(), "type2", { test: 22 })];
+      commit = new Commit(uuid(), "master", "1", 1, events);
+      partition.append(commit);
+
+      const res = await partition.queryStream("1", 2);
+      expect(res).toHaveLength(1);
     });
-    it("should skip events and split commit if inbetween", function () {
-      var store = new Store();
-      store.openPartition("1").then(function (partition) {
-        var events = [new Event(uuid(), "type1", { test: 11 }), new Event(uuid(), "type1", { test: 12 })];
-        var commit = new Commit(uuid(), "master", "1", 0, events);
-        partition.append(commit);
-        var events = [new Event(uuid(), "type2", { test: 22 })];
-        var commit = new Commit(uuid(), "master", "1", 1, events);
-        partition.append(commit);
-        partition.queryStream("1", 1).then(function (res) {
-          res.length.should.equal(2);
-          res[0].events.length.should.equal(1);
-        });
-      });
+
+    it("should skip events and split commit if inbetween", async () => {
+      const store = new Store();
+      const partition = await store.openPartition("1");
+
+      let events = [new Event(uuid(), "type1", { test: 11 }), new Event(uuid(), "type1", { test: 12 })];
+      let commit = new Commit(uuid(), "master", "1", 0, events);
+      partition.append(commit);
+
+      events = [new Event(uuid(), "type2", { test: 22 })];
+      commit = new Commit(uuid(), "master", "1", 1, events);
+      partition.append(commit);
+
+      const res = await partition.queryStream("1", 1);
+      expect(res).toHaveLength(2);
+      expect(res[0].events).toHaveLength(1);
     });
   });
-  describe("#concurrency", function () {
-    it("same commit sequence twice should throw", function (done) {
-      var store = new Store();
-      store
-        .openPartition("1")
-        .then(function (partition) {
-          var events = [new Event(uuid(), "type1", { test: 11 })];
-          var commit = new Commit(uuid(), "master", "1", 0, events);
-          var commit2 = new Commit(uuid(), "master", "1", 0, events);
-          return Promise.join(partition.append(commit), partition.append(commit2), function () {
-            done(new Error("Should have thrown concurrency error"));
-          });
-        })
-        .catch(PersistenceConcurrencyError, function (err) {
-          done();
-        })
-        .catch(function (err) {
-          console.log("err" + err);
-          done(err);
-        });
+  describe("#concurrency", () => {
+    it("same commit sequence twice should throw", async () => {
+      const store = new Store();
+      const partition = await store.openPartition("1");
+
+      const events = [new Event(uuid(), "type1", { test: 11 })];
+      const commit = new Commit(uuid(), "master", "1", 0, events);
+      const commit2 = new Commit(uuid(), "master", "1", 0, events);
+
+      await expect(async () => await Promise.all(partition.append(commit), partition.append(commit2))).rejects.toThrow("Concurrency error on stream 1");
     });
   });
-  describe("#duplicateEvents", function () {
-    it("same commit twice should throw", function (done) {
-      var store = new Store();
-      store.openPartition("1").then(function (partition) {
-        var events = [new Event(uuid(), "type1", { test: 11 })];
-        var commit = new Commit(uuid(), "master", "1", 0, events);
-        partition
-          .append(commit)
-          .then(function () {
-            return partition.append(commit);
-          })
-          .then(function () {
-            done(new Error("Should have DuplicateCommitError"));
-          })
-          .catch(PersistenceDuplicateCommitError, function (err) {
-            done();
-          })
-          .catch(function (err) {
-            done(err);
-          });
-      });
+
+  describe("#duplicateEvents", () => {
+    it("same commit twice should throw", async () => {
+      const store = new Store();
+      const partition = await store.openPartition("1");
+
+      const events = [new Event(uuid(), "type1", { test: 11 })];
+      const commit = new Commit(uuid(), "master", "1", 0, events);
+
+      await partition.append(commit);
+      await expect(async () => partition.append(commit)).rejects.toThrow(`Duplicate commit of ${commit.id}`);
     });
   });
-  describe("#partition", function () {
-    it("getting the same partition twice should return same instance", function (done) {
-      var store = new Store();
-      Promise.join(store.openPartition("1"), store.openPartition("1"), function (p1, p2) {
-        p1.should.equal(p2);
-        done();
-      });
+
+  describe("#partition", () => {
+    it("getting the same partition twice should return same instance", async () => {
+      const store = new Store();
+      const [p1, p2] = await Promise.all([store.openPartition("1"), store.openPartition("1")]);
+      expect(p1).toBe(p2);
     });
-    it("not indicating partition name should give master partition", function (done) {
-      var store = new Store();
-      Promise.join(store.openPartition(), store.openPartition("master"), function (p1, p2) {
-        p1.should.equal(p2);
-        done();
-      });
+
+    it("not indicating partition name should give master partition", async () => {
+      const store = new Store();
+      const [p1, p2] = await Promise.all([store.openPartition(), store.openPartition("master")]);
+      expect(p1).toBe(p2);
     });
   });
-  describe("#storeSnapshot", function () {
-    it("should return previously stored snapshot", function (done) {
-      var store = new Store();
-      store.openPartition("1").then(function (part) {
-        part.storeSnapshot("stream1", { iAmSnapshot: true }, 10).then(function (snapshot) {
-          part.loadSnapshot("stream1").then(function (newSnapshot) {
-            newSnapshot.should.equal(snapshot);
-            done();
-          });
-        });
-      });
+
+  describe("#storeSnapshot", () => {
+    it("should return previously stored snapshot", async () => {
+      const store = new Store();
+      const part = await store.openPartition("1");
+
+      const snapshot = await part.storeSnapshot("stream1", { iAmSnapshot: true }, 10);
+      const newSnapshot = await part.loadSnapshot("stream1");
+
+      expect(newSnapshot).toBe(snapshot);
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.{test,spec}.?[jt]s", "test/**/*.[jt]s"],
+  },
+});


### PR DESCRIPTION
>[!IMPORTANT]
>Targetting the `style/biome` branch, since this was branched out from that one. If the other branch is merged, this will be automatically redirected.

>[!NOTE]
>With this PR, the result from `npm audit` goes from `30 vulnerabilities (2 low, 7 moderate, 14 high, 7 critical)` to `found 0 vulnerabilities`

Replace mocha, should, and istanbul with vitest. Mainly because I'll likely add a lot of new tests relatively soon, and I don't want to increase the tech debt of this package.

Rewrite the tests to use async test functions instead of calling the done context function. Replace usage of should for assertions with expect assertions. The tests become a lot more clear and we avoid using the deprecated done context function.